### PR TITLE
Uppdated RustRepo::sparse_path()

### DIFF
--- a/holger-rust-repository/Cargo.toml
+++ b/holger-rust-repository/Cargo.toml
@@ -22,4 +22,5 @@ holger-traits = {version = "0.2.0"}
 sha2 = "0.11.0-rc.0"
 hex = "0.4.3"
 
-
+[[example]]
+name = "get_path"

--- a/holger-rust-repository/examples/get_path.rs
+++ b/holger-rust-repository/examples/get_path.rs
@@ -5,4 +5,8 @@ fn main() {
     println!("path: {:?}", RustRepo::sparse_path("ab"));
     println!("path: {:?}", RustRepo::sparse_path("abc"));
     println!("path: {:?}", RustRepo::sparse_path("tokio"));
+
+    let tuple_path: (&str, &str, &str) = RustRepo::sparse_path("tokio").into();
+
+    println!("Tuple: {:?}", tuple_path);
 }

--- a/holger-rust-repository/examples/get_path.rs
+++ b/holger-rust-repository/examples/get_path.rs
@@ -1,4 +1,7 @@
 use holger_rust_repository::RustRepo;
+
+type RPath<'a> = (&'a str, &'a str, &'a str);
+
 fn main() {
     //let repo = RustRepo::new("kalle".to_string());
     println!("path: {:?}", RustRepo::sparse_path("a"));
@@ -6,7 +9,7 @@ fn main() {
     println!("path: {:?}", RustRepo::sparse_path("abc"));
     println!("path: {:?}", RustRepo::sparse_path("tokio"));
 
-    let tuple_path: (&str, &str, &str) = RustRepo::sparse_path("tokio").into();
+    let tuple_path: RPath = RustRepo::sparse_path("tokio").into();
 
     println!("Tuple: {:?}", tuple_path);
 }

--- a/holger-rust-repository/examples/get_path.rs
+++ b/holger-rust-repository/examples/get_path.rs
@@ -1,0 +1,8 @@
+use holger_rust_repository::RustRepo;
+fn main() {
+    //let repo = RustRepo::new("kalle".to_string());
+    println!("path: {:?}", RustRepo::sparse_path("a"));
+    println!("path: {:?}", RustRepo::sparse_path("ab"));
+    println!("path: {:?}", RustRepo::sparse_path("abc"));
+    println!("path: {:?}", RustRepo::sparse_path("tokio"));
+}

--- a/holger-rust-repository/src/lib.rs
+++ b/holger-rust-repository/src/lib.rs
@@ -10,6 +10,13 @@ pub struct RustRepo {
     pub artifacts: Vec<ArtifactId>, // cached list of artifacts
 }
 
+#[derive(Debug)]
+pub struct RepoPath<'a> {
+    pub p1: &'a str,
+    pub p2: &'a str,
+    pub name: &'a str,
+}
+
 impl RustRepo {
     pub fn new(name: String) -> Self {
         RustRepo {
@@ -22,19 +29,30 @@ impl RustRepo {
         }
     }
 
-    /// Convert crate name to Cargo sparse 5-part path (p1, p2, name)
-    pub fn sparse_path(crate_name: &str) -> (String, String, String) {
-        let mut chars = crate_name.chars();
-
-        let p1: String = chars.by_ref().take(2).collect();
-        let mut p2: String = chars.by_ref().take(2).collect();
-
-        // Cargo uses "_" as filler if name is shorter than 4 chars
-        if p2.is_empty() {
-            p2.push('_');
+    /// Convert crate name to Cargo sparse 3-part path (p1, p2, name)
+    pub fn sparse_path<'a>(crate_name: &'a str) -> RepoPath<'a> {
+        match (crate_name, crate_name.len()) {
+            (name, 1) => RepoPath {
+                p1: "1",
+                p2: name,
+                name,
+            },
+            (name, 2) => RepoPath {
+                p1: "2",
+                p2: name,
+                name,
+            },
+            (name, 3) => RepoPath {
+                p1: "3",
+                p2: &name[0..1],
+                name,
+            },
+            (name, _n) => RepoPath {
+                p1: &name[0..2],
+                p2: &name[2..4],
+                name,
+            },
         }
-
-        (p1, p2, crate_name.to_string())
     }
 
     /// Reverse matcher: takes a sparse path slice ["xx","yy","name"] -> crate name

--- a/holger-rust-repository/src/lib.rs
+++ b/holger-rust-repository/src/lib.rs
@@ -1,16 +1,16 @@
-use sha2::{Sha256, Digest};
-use std::any::Any;
 use anyhow::anyhow;
 use holger_traits::{ArtifactFormat, ArtifactId, RepositoryBackendTrait};
+use sha2::{Digest, Sha256};
+use std::any::Any;
 
 /// Minimal RustRepo example
 pub struct RustRepo {
     pub name: String,
-//    pub format: ArtifactFormat,
+    //    pub format: ArtifactFormat,
     pub artifacts: Vec<ArtifactId>, // cached list of artifacts
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, PartialOrd)]
 pub struct RepoPath<'a> {
     pub p1: &'a str,
     pub p2: &'a str,
@@ -20,7 +20,6 @@ pub struct RepoPath<'a> {
 impl RustRepo {
     pub fn new(name: String) -> Self {
         RustRepo {
-
             // initialize fields if any; if none, leave empty struct
             // Example: name
             // name,
@@ -66,8 +65,8 @@ impl RustRepo {
     }
     #[inline]
     pub fn crate_sha256_hex(data: &[u8]) -> String {
-        use sha2::{Sha256, Digest};
-        use hex::encode; // Add `hex = "0.4"` to Cargo.toml
+        use hex::encode;
+        use sha2::{Digest, Sha256}; // Add `hex = "0.4"` to Cargo.toml
 
         let mut hasher = Sha256::new();
         hasher.update(data);
@@ -75,7 +74,6 @@ impl RustRepo {
         encode(hash) // Convert to lowercase hex string
     }
 }
-
 
 impl RepositoryBackendTrait for RustRepo {
     fn name(&self) -> &str {
@@ -112,8 +110,12 @@ impl RepositoryBackendTrait for RustRepo {
 
             // Sparse crate metadata → /rust-prod/index/se/rd/serde
             [repo, "index", p1, p2, crate_name] if *repo == self.name() => {
-                if let Some(actual_name) = RustRepo::sparse_crate_from_parts(&[p1, p2, crate_name]) {
-                    println!("Sparse crate metadata request: {}/{}/{}", p1, p2, actual_name);
+                if let Some(actual_name) = RustRepo::sparse_crate_from_parts(&[p1, p2, crate_name])
+                {
+                    println!(
+                        "Sparse crate metadata request: {}/{}/{}",
+                        p1, p2, actual_name
+                    );
 
                     let fake_crate_data = b"FAKE_CRATE_CONTENT";
                     let checksum_hex = RustRepo::crate_sha256_hex(fake_crate_data);
@@ -152,7 +154,6 @@ impl RepositoryBackendTrait for RustRepo {
     fn format(&self) -> ArtifactFormat {
         ArtifactFormat::Rust
     }
-
 
     fn is_writable(&self) -> bool {
         todo!()

--- a/holger-rust-repository/src/lib.rs
+++ b/holger-rust-repository/src/lib.rs
@@ -167,4 +167,56 @@ impl RepositoryBackendTrait for RustRepo {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    #[test]
+    fn sparse_path_test_1() {
+        let path = RustRepo::sparse_path("a");
+        assert_eq!(
+            path,
+            RepoPath {
+                p1: "1",
+                p2: "a",
+                name: "a"
+            }
+        );
+    }
+    #[test]
+    fn sparse_path_test_2() {
+        let path = RustRepo::sparse_path("ab");
+        assert_eq!(
+            path,
+            RepoPath {
+                p1: "2",
+                p2: "ab",
+                name: "ab"
+            }
+        );
+    }
+    #[test]
+    fn sparse_path_test_3() {
+        let path = RustRepo::sparse_path("abc");
+        assert_eq!(
+            path,
+            RepoPath {
+                p1: "3",
+                p2: "a",
+                name: "abc"
+            }
+        );
+    }
+    #[test]
+    fn sparse_path_test_n() {
+        let path = RustRepo::sparse_path("abcd");
+        assert_eq!(
+            path,
+            RepoPath {
+                p1: "ab",
+                p2: "cd",
+                name: "abcd"
+            }
+        );
+    }
+}

--- a/holger-rust-repository/src/lib.rs
+++ b/holger-rust-repository/src/lib.rs
@@ -17,6 +17,12 @@ pub struct RepoPath<'a> {
     pub name: &'a str,
 }
 
+impl<'a> From<RepoPath<'a>> for (&'a str, &'a str, &'a str) {
+    fn from(path: RepoPath<'a>) -> Self {
+        (path.p1, path.p2, path.name)
+    }
+}
+
 impl RustRepo {
     pub fn new(name: String) -> Self {
         RustRepo {
@@ -184,6 +190,7 @@ mod tests {
             }
         );
     }
+
     #[test]
     fn sparse_path_test_2() {
         let path = RustRepo::sparse_path("ab");
@@ -196,6 +203,7 @@ mod tests {
             }
         );
     }
+
     #[test]
     fn sparse_path_test_3() {
         let path = RustRepo::sparse_path("abc");
@@ -208,6 +216,7 @@ mod tests {
             }
         );
     }
+
     #[test]
     fn sparse_path_test_n() {
         let path = RustRepo::sparse_path("abcd");
@@ -219,5 +228,11 @@ mod tests {
                 name: "abcd"
             }
         );
+    }
+
+    #[test]
+    fn sparse_path_into_tuple() {
+        let path: (&str, &str, &str) = RustRepo::sparse_path("abcd").into();
+        assert_eq!(path, ("ab", "cd", "abcd"));
     }
 }


### PR DESCRIPTION
Uppdated RustRepo::sparse_path() to better follow the cargo index format.